### PR TITLE
Allow to disable tests through BUILD_TESTING=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(linq)
-
-enable_testing()
+project(linq CXX)
 
 find_package(Boost)
 
@@ -37,6 +35,10 @@ install(FILES
 install(FILES linq.h DESTINATION include)
 install(DIRECTORY linq DESTINATION include)
 
-add_executable(linq-test test.cpp)
-target_link_libraries(linq-test linq ${Boost_test_LIBRARY_RELEASE})
-add_test(NAME linq-test COMMAND linq-test)
+include(CTest)
+
+if (BUILD_TESTING)
+    add_executable(linq-test test.cpp)
+    target_link_libraries(linq-test linq ${Boost_test_LIBRARY_RELEASE})
+    add_test(NAME linq-test COMMAND linq-test)
+endif (BUILD_TESTING)


### PR DESCRIPTION
Hi!
I am creating a package for this awesome library in `vcpkg`: https://github.com/microsoft/vcpkg/pull/6426
It would be nice to have an option to disable tests.
By including `CTest.cmake` module, we got a `BUILD_TESTING` option which has a default value: ON.
`CTest.cmake` module will also call `enable_testing()` for us if `BUILD_TESTING` is `ON`.